### PR TITLE
feature: Update Detekt to 1.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.7.1
+  codacy: codacy/base@2.9.3
   codacy_plugins_test: codacy/plugins-test@0.10.6
 
 workflows:
@@ -17,9 +17,8 @@ workflows:
                  scalafmt::test;
                  test:scalafmt::test;
                  sbt:scalafmt::test;
-                 set name := \"$CIRCLE_PROJECT_REPONAME\";
-                 set version in Docker := \"latest\";
-                 clean;
+                 set Docker / version := \"latest\";
+                 set scalacOptions ++= Seq(\"-opt:l:inline\", \"-opt-inline-from:**\");
                  docker:publishLocal"
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
           persist_to_workspace: true

--- a/build.sbt
+++ b/build.sbt
@@ -27,16 +27,16 @@ resolvers += Resolver.jcenterRepo
 libraryDependencies ++= {
   val toolVersion = toolVersionKey.value
   Seq(
-    "com.codacy" %% "codacy-engine-scala-seed" % "4.0.2",
-    "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+    "com.codacy" %% "codacy-engine-scala-seed" % "4.0.3",
+    "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
     "io.gitlab.arturbosch.detekt" % "detekt-core" % toolVersion,
     "io.gitlab.arturbosch.detekt" % "detekt-api" % toolVersion,
     "io.gitlab.arturbosch.detekt" % "detekt-rules" % toolVersion,
     "io.gitlab.arturbosch.detekt" % "detekt-cli" % toolVersion,
     "io.gitlab.arturbosch.detekt" % "detekt-generator" % toolVersion,
     "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
-    "org.yaml" % "snakeyaml" % "1.25",
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.10.1"
+    "org.yaml" % "snakeyaml" % "1.26",
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.10.3"
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-resolvers += Resolver.jcenterRepo
-addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "17.1.5")
+addSbtPlugin("com.codacy" % "codacy-sbt-plugin" % "20.0.4")
+addSbtPlugin("com.hanhuy.sbt" % "kotlin-plugin" % "2.0.0")

--- a/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
+++ b/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
@@ -1,0 +1,22 @@
+package codacy.detekt
+
+import java.util.concurrent.ForkJoinPool
+import java.nio.file.Path
+
+import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import io.gitlab.arturbosch.detekt.api.Config
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.config.LanguageVersion
+
+class ProcessingSettingsFactory {
+  companion object {
+    @JvmStatic
+    fun create(paths: List<Path>, config: Config): ProcessingSettings {
+      return ProcessingSettings (inputPaths = paths, config = config, outPrinter = System.out, errPrinter = System.err)
+    }
+    @JvmStatic
+    fun create(paths: List<Path>): ProcessingSettings {
+      return ProcessingSettings (inputPaths = paths, outPrinter = System.out, errPrinter = System.err)
+    }
+  }
+}

--- a/src/main/resources/docs/description/LongParameterList.md
+++ b/src/main/resources/docs/description/LongParameterList.md
@@ -1,6 +1,6 @@
 # LongParameterList
 
-Reports functions which have more parameters than a certain threshold (default: 6).
+Reports functions and constructors which have more parameters than a certain threshold.
 
 
 [Source](https://arturbosch.github.io/detekt/complexity.html#longparameterlist)

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name" : "Detekt",
-  "version" : "1.7.0",
+  "version" : "1.7.1",
   "patterns" : [ {
     "patternId" : "CommentOverPrivateFunction",
     "level" : "Warning",

--- a/src/main/scala/codacy/detekt/Detekt.scala
+++ b/src/main/scala/codacy/detekt/Detekt.scala
@@ -1,8 +1,8 @@
 package codacy.detekt
 
 import java.nio.file.{Path, Paths}
-import better.files._
 
+import better.files._
 import com.codacy.plugins.api
 import com.codacy.plugins.api._
 import com.codacy.plugins.api.results.{Pattern, Result, Tool}
@@ -16,7 +16,6 @@ import play.api.libs.json.{JsString, Json}
 
 import scala.jdk.CollectionConverters._
 import scala.util.Try
-
 import scala.collection.parallel.CollectionConverters._
 
 object Detekt extends Tool {
@@ -39,7 +38,7 @@ object Detekt extends Tool {
       val sourcePath = Paths.get(source.path)
       val yamlConfig = getYamlConfig(configuration, sourcePath)
 
-      val findings = getResults(sourcePath, files, yamlConfig, parallel = true)
+      val findings = getResults(sourcePath, files, yamlConfig)
 
       findings.map { finding =>
         Result.Issue(
@@ -106,13 +105,8 @@ object Detekt extends Tool {
     new YamlConfig(ourConf.asJava, null, null)
   }
 
-  private def getResults(
-      path: Path,
-      filesOpt: Option[Set[api.Source.File]],
-      yamlConf: YamlConfig,
-      parallel: Boolean
-  ): List[Finding] = {
-    val settings = new ProcessingSettings(List(path).asJava, yamlConf, null, parallel)
+  private def getResults(path: Path, filesOpt: Option[Set[api.Source.File]], yamlConf: YamlConfig): List[Finding] = {
+    val settings = ProcessingSettingsFactory.create(Seq(path).asJava, yamlConf)
     val providers = new RuleSetLocator(settings).load()
     val processors = List.empty[FileProcessListener]
     val detektor = new Detektor(settings, providers, processors.asJava)

--- a/src/main/scala/codacy/detekt/DocGenerator.scala
+++ b/src/main/scala/codacy/detekt/DocGenerator.scala
@@ -3,7 +3,7 @@ package codacy.detekt
 import better.files.File
 import io.gitlab.arturbosch.detekt.api._
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
-import io.gitlab.arturbosch.detekt.core.{KtCompiler, KtTreeCompiler, ProcessingSettings}
+import io.gitlab.arturbosch.detekt.core.{KtCompiler, KtTreeCompiler}
 import io.gitlab.arturbosch.detekt.generator.collection.DetektCollector
 import org.jetbrains.kotlin.psi.KtFile
 import play.api.libs.json.{JsArray, Json}
@@ -15,7 +15,7 @@ object DocGenerator {
 
   def main(args: Array[String]): Unit = {
     args.headOption.fold {
-      throw new Exception("Version parameter is required (ex: 1.7.0)")
+      throw new Exception("Version parameter is required (ex: 1.7.1)")
     } { version =>
       val rules = generateRules
 
@@ -142,7 +142,9 @@ object DocGenerator {
   private def getExtendedDescriptions(version: String): Map[String, String] = {
     val tmpDirectory = File.newTemporaryDirectory()
 
-    Process(Seq("git", "clone", "--branch", version, "git://github.com/arturbosch/detekt", tmpDirectory.pathAsString)).!
+    Process(
+      Seq("git", "clone", "--branch", s"v$version", "git://github.com/arturbosch/detekt", tmpDirectory.pathAsString)
+    ).!
 
     val filePaths = (File(tmpDirectory.pathAsString) / "detekt-rules" / "src" / "main")
       .listRecursively()
@@ -150,7 +152,7 @@ object DocGenerator {
       .map(_.path)
 
     val collector = new DetektCollector()
-    val compiler = new KtTreeCompiler(new ProcessingSettings(List.empty.asJava), new KtCompiler())
+    val compiler = new KtTreeCompiler(ProcessingSettingsFactory.create(Seq.empty.asJava), new KtCompiler())
 
     val ktFiles: Array[KtFile] = filePaths
       .to(Array)


### PR DESCRIPTION
- Enable Scala compiler optimizer
- Add some Kotlin glue code because you can't use Kotlin named parameters from Scala
- Bump sbt to 1.3.8
- Add Kotlin sbt plugin