### PR TITLE
feature: Bump detekt to version 1.14.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= {
   Seq(
-    "com.codacy" %% "codacy-engine-scala-seed" % "5.0.1",
+    "com.codacy" %% "codacy-engine-scala-seed" % "5.0.2",
     "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
     "io.gitlab.arturbosch.detekt" % "detekt-core" % detektVersion.value,
     "io.gitlab.arturbosch.detekt" % "detekt-api" % detektVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "codacy-detekt"
 
 scalaVersion := "2.13.1"
 
-lazy val detektVersion = Def.setting("1.10.0")
+lazy val detektVersion = Def.setting("1.14.2")
 
 Compile / sourceGenerators += Def.task {
   val file = (Compile / sourceManaged).value / "codacy" / "detekt" / "Versions.scala"

--- a/docs/description/AbsentOrWrongFileLicense.md
+++ b/docs/description/AbsentOrWrongFileLicense.md
@@ -1,6 +1,8 @@
 # AbsentOrWrongFileLicense
 
-This rule will report every Kotlin source file which doesn't have required license header.
+This rule will report every Kotlin source file which doesn't have the required license header.
+The rule checks each Kotlin source file whether the header starts with the read text from the passed file in the
+`licenseTemplateFile` configuration option.
 
 
 [Source](https://arturbosch.github.io/detekt/comments.html#absentorwrongfilelicense)

--- a/docs/description/ArrayPrimitive.md
+++ b/docs/description/ArrayPrimitive.md
@@ -3,7 +3,7 @@
 Using Array<Primitive> leads to implicit boxing and performance hit. Prefer using Kotlin specialized Array
 Instances.
 
-As stated in the Kotlin [documention](https://kotlinlang.org/docs/reference/basic-types.html#arrays) Kotlin has
+As stated in the Kotlin [documentation](https://kotlinlang.org/docs/reference/basic-types.html#arrays) Kotlin has
 specialized arrays to represent primitive types without boxing overhead, such as `IntArray`, `ByteArray` and so on.
 
 ## Noncompliant Code

--- a/docs/description/ClassOrdering.md
+++ b/docs/description/ClassOrdering.md
@@ -1,0 +1,41 @@
+# ClassOrdering
+
+This rule ensures class contents are ordered as follows as recommended by the Kotlin
+[Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#class-layout):
+- Property declarations and initializer blocks
+- Secondary constructors
+- Method declarations
+- Companion object
+
+## Noncompliant Code
+
+```kotlin
+class OutOfOrder {
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+
+    fun returnX(): Int {
+        return x
+    }
+
+    private val x = 2
+}
+```
+## Compliant Code
+
+```kotlin
+class InOrder {
+    private val x = 2
+
+    fun returnX(): Int {
+        return x
+    }
+
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
+}
+```
+
+[Source](https://arturbosch.github.io/detekt/style.html#classordering)

--- a/docs/description/GlobalCoroutineUsage.md
+++ b/docs/description/GlobalCoroutineUsage.md
@@ -1,0 +1,34 @@
+# GlobalCoroutineUsage
+
+Report usages of `GlobalScope.launch` and `GlobalScope.async`. It is highly discouraged by the Kotlin documentation:
+
+> Global scope is used to launch top-level coroutines which are operating on the whole application lifetime and are
+> not cancelled prematurely.
+
+> Application code usually should use an application-defined CoroutineScope. Using async or launch on the instance
+> of GlobalScope is highly discouraged.
+
+See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-global-scope/
+
+## Noncompliant Code
+
+```kotlin
+fun foo() {
+    GlobalScope.launch { delay(1_000L) }
+}
+```
+## Compliant Code
+
+```kotlin
+val scope = CoroutineScope(Dispatchers.Default)
+
+fun foo() {
+    scope.launch { delay(1_000L) }
+}
+
+fun onDestroy() {
+    scope.cancel()
+}
+```
+
+[Source](https://arturbosch.github.io/detekt/coroutines.html#globalcoroutineusage)

--- a/docs/description/LibraryEntitiesShouldNotBePublic.md
+++ b/docs/description/LibraryEntitiesShouldNotBePublic.md
@@ -1,0 +1,18 @@
+# LibraryEntitiesShouldNotBePublic
+
+Library typealias and classes should be internal or private.
+
+## Noncompliant Code
+
+```kotlin
+// code from a library
+class A
+```
+## Compliant Code
+
+```kotlin
+// code from a library
+internal class A
+```
+
+[Source](https://arturbosch.github.io/detekt/style.html#libraryentitiesshouldnotbepublic)

--- a/docs/description/NonBooleanPropertyPrefixedWithIs.md
+++ b/docs/description/NonBooleanPropertyPrefixedWithIs.md
@@ -1,0 +1,17 @@
+# NonBooleanPropertyPrefixedWithIs
+
+Reports when property with 'is' prefix doesn't have a boolean type.
+Please check the [chapter 8.3.2 at Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
+
+## Noncompliant Code
+
+```kotlin
+val isEnabled: Int = 500
+```
+## Compliant Code
+
+```kotlin
+val isEnabled: Boolean = false
+```
+
+[Source](https://arturbosch.github.io/detekt/naming.html#nonbooleanpropertyprefixedwithis)

--- a/docs/description/NullableToStringCall.md
+++ b/docs/description/NullableToStringCall.md
@@ -1,0 +1,28 @@
+# NullableToStringCall
+
+Turn on this rule to flag 'toString' calls with a nullable receiver that may return the string "null".
+
+## Noncompliant Code
+
+```kotlin
+fun foo(a: Any?): String {
+    return a.toString()
+}
+
+fun bar(a: Any?): String {
+    return "$a"
+}
+```
+## Compliant Code
+
+```kotlin
+fun foo(a: Any?): String {
+    return a?.toString() ?: "-"
+}
+
+fun bar(a: Any?): String {
+    return "${a ?: "-"}"
+}
+```
+
+[Source](https://arturbosch.github.io/detekt/potential-bugs.html#nullabletostringcall)

--- a/docs/description/RedundantSuspendModifier.md
+++ b/docs/description/RedundantSuspendModifier.md
@@ -1,0 +1,25 @@
+# RedundantSuspendModifier
+
+`suspend` modifier should only be used where needed, otherwise the function can only be used from other suspending
+functions. This needlessly restricts use of the function and should be avoided by removing the `suspend` modifier
+where it's not needed.
+
+Based on code from Kotlin project:
+https://github.com/JetBrains/kotlin/blob/v1.3.61/idea/src/org/jetbrains/kotlin/idea/inspections/RedundantSuspendModifierInspection.kt
+
+## Noncompliant Code
+
+```kotlin
+suspend fun normalFunction() {
+println("string")
+}
+```
+## Compliant Code
+
+```kotlin
+fun normalFunction() {
+println("string")
+}
+```
+
+[Source](https://arturbosch.github.io/detekt/coroutines.html#redundantsuspendmodifier)

--- a/docs/description/ReplaceSafeCallChainWithRun.md
+++ b/docs/description/ReplaceSafeCallChainWithRun.md
@@ -1,0 +1,30 @@
+# ReplaceSafeCallChainWithRun
+
+Chains of safe calls on non-nullable types are redundant and can be removed by enclosing the redundant safe calls in
+a `run {}` block. This improves code coverage and reduces cyclomatic complexity as redundant null checks are removed.
+
+This rule only checks from the end of a chain and works backwards, so it won't recommend inserting run blocks in the
+middle of a safe call chain as that is likely to make the code more difficult to understand.
+
+The rule will check for every opportunity to replace a safe call when it sits at the end of a chain, even if there's
+only one, as that will still improve code coverage and reduce cyclomatic complexity.
+
+## Noncompliant Code
+
+```kotlin
+val x = System.getenv()
+    ?.getValue("HOME")
+    ?.toLowerCase()
+    ?.split("/") ?: emptyList()
+```
+## Compliant Code
+
+```kotlin
+val x = getenv()?.run {
+    getValue("HOME")
+        .toLowerCase()
+        .split("/")
+} ?: emptyList()
+```
+
+[Source](https://arturbosch.github.io/detekt/complexity.html#replacesafecallchainwithrun)

--- a/docs/description/SuspendFunWithFlowReturnType.md
+++ b/docs/description/SuspendFunWithFlowReturnType.md
@@ -1,0 +1,47 @@
+# SuspendFunWithFlowReturnType
+
+Functions that return `Flow` from `kotlinx.coroutines.flow` should not be marked as `suspend`.
+`Flows` are intended to be cold observable streams. The act of simply invoking a function that
+returns a `Flow`, should not have any side effects. Only once collection begins against the
+returned `Flow`, should work actually be done.
+
+See https://kotlinlang.org/docs/reference/coroutines/flow.html#flows-are-cold
+
+## Noncompliant Code
+
+```kotlin
+suspend fun observeSignals(): Flow<Unit> {
+    val pollingInterval = getPollingInterval() // Done outside of the flow builder block.
+    return flow {
+        while (true) {
+            delay(pollingInterval)
+            emit(Unit)
+        }
+    }
+}
+
+private suspend fun getPollingInterval(): Long {
+    // Return the polling interval from some repository
+    // in a suspending manner.
+}
+```
+## Compliant Code
+
+```kotlin
+fun observeSignals(): Flow<Unit> {
+    return flow {
+        val pollingInterval = getPollingInterval() // Moved into the flow builder block.
+        while (true) {
+            delay(pollingInterval)
+            emit(Unit)
+        }
+    }
+}
+
+private suspend fun getPollingInterval(): Long {
+    // Return the polling interval from some repository
+    // in a suspending manner.
+}
+```
+
+[Source](https://arturbosch.github.io/detekt/coroutines.html#suspendfunwithflowreturntype)

--- a/docs/description/UnnecessaryLet.md
+++ b/docs/description/UnnecessaryLet.md
@@ -7,22 +7,20 @@ to reduce visual complexity
 ## Noncompliant Code
 
 ```kotlin
+a.let { print(it) } // can be replaced with `print(a)`
 a.let { it.plus(1) } // can be replaced with `a.plus(1)`
 a?.let { it.plus(1) } // can be replaced with `a?.plus(1)`
-a.let { that -> that.plus(1) } // can be replaced with `a.plus(1)`
-a?.let { that -> that.plus(1) } // can be replaced with `a?.plus(1)`
 a?.let { that -> that.plus(1) }?.let { it.plus(1) } // can be replaced with `a?.plus(1)?.plus(1)`
+a.let { 1.plus(1) } // can be replaced with `1.plus(1)`
+a?.let { 1.plus(1) } // can be replaced with `if (a != null) 1.plus(1)`
 ```
 ## Compliant Code
 
 ```kotlin
 a?.let { print(it) }
-a.let { print(it) }
-a?.let { msg -> print(msg) }
-a.let { msg -> print(msg) }
 a?.let { 1.plus(it) } ?.let { msg -> print(msg) }
 a?.let { it.plus(it) }
-a?.let { param -> param.plus(param) }
+val b = a?.let { 1.plus(1) }
 ```
 
 [Source](https://arturbosch.github.io/detekt/style.html#unnecessarylet)

--- a/docs/description/UseCheckNotNull.md
+++ b/docs/description/UseCheckNotNull.md
@@ -1,0 +1,16 @@
+# UseCheckNotNull
+
+Turn on this rule to flag `check` calls for not-null check that can be replaced with a `checkNotNull` call.
+
+## Noncompliant Code
+
+```kotlin
+check(x != null)
+```
+## Compliant Code
+
+```kotlin
+checkNotNull(x)
+```
+
+[Source](https://arturbosch.github.io/detekt/style.html#usechecknotnull)

--- a/docs/description/UseDataClass.md
+++ b/docs/description/UseDataClass.md
@@ -9,7 +9,6 @@ Read more about `data class`: https://kotlinlang.org/docs/reference/data-classes
 
 ```kotlin
 class DataClassCandidate(val i: Int) {
-
     val i2: Int = 0
 }
 ```
@@ -17,6 +16,11 @@ class DataClassCandidate(val i: Int) {
 
 ```kotlin
 data class DataClass(val i: Int, val i2: Int)
+
+// classes with delegating interfaces are compliant
+interface I
+class B() : I
+class A(val b: B) : I by b
 ```
 
 [Source](https://arturbosch.github.io/detekt/style.html#usedataclass)

--- a/docs/description/UseEmptyCounterpart.md
+++ b/docs/description/UseEmptyCounterpart.md
@@ -1,0 +1,24 @@
+# UseEmptyCounterpart
+
+Instantiation of an object's "empty" state should use the object's "empty" initializer for clarity purposes.
+
+## Noncompliant Code
+
+```kotlin
+arrayOf()
+listOf() // or listOfNotNull()
+mapOf()
+sequenceOf()
+setOf()
+```
+## Compliant Code
+
+```kotlin
+emptyArray()
+emptyList()
+emptyMap()
+emptySequence()
+emptySet()
+```
+
+[Source](https://arturbosch.github.io/detekt/style.html#useemptycounterpart)

--- a/docs/description/UseRequireNotNull.md
+++ b/docs/description/UseRequireNotNull.md
@@ -1,0 +1,16 @@
+# UseRequireNotNull
+
+Turn on this rule to flag `require` calls for not-null check that can be replaced with a `requireNotNull` call.
+
+## Noncompliant Code
+
+```kotlin
+require(x != null)
+```
+## Compliant Code
+
+```kotlin
+requireNotNull(x)
+```
+
+[Source](https://arturbosch.github.io/detekt/style.html#userequirenotnull)

--- a/docs/description/UselessCallOnNotNull.md
+++ b/docs/description/UselessCallOnNotNull.md
@@ -12,6 +12,7 @@ Rule adapted from Kotlin's IntelliJ plugin: https://github.com/JetBrains/kotlin/
 ```kotlin
 val testList = listOf("string").orEmpty()
 val testList2 = listOf("string").orEmpty().map { _ }
+val testList3 = listOfNotNull("string")
 val testString = ""?.isNullOrBlank()
 ```
 ## Compliant Code
@@ -19,6 +20,7 @@ val testString = ""?.isNullOrBlank()
 ```kotlin
 val testList = listOf("string")
 val testList2 = listOf("string").map { }
+val testList3 = listOf("string")
 val testString = ""?.isBlank()
 ```
 

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -89,6 +89,11 @@
   "timeToFix" : 5,
   "title" : "Expression with labels increase complexity and affect maintainability."
 }, {
+  "patternId" : "ReplaceSafeCallChainWithRun",
+  "description" : "Chains of safe calls on non-nullable types can be surrounded with run {}",
+  "timeToFix" : 5,
+  "title" : "Chains of safe calls on non-nullable types can be surrounded with run {}"
+}, {
   "patternId" : "EmptyCatchBlock",
   "description" : "Empty catch block detected. Empty catch blocks indicate that an exception is ignored and not handled.",
   "timeToFix" : 5,
@@ -233,6 +238,16 @@
   "description" : "Multiple annotations should be placed on separate lines. ",
   "timeToFix" : 5,
   "title" : "Multiple annotations should be placed on separate lines. "
+}, {
+  "patternId" : "AnnotationSpacing",
+  "description" : "There should not be empty lines between an annotation and the object that it's annotating",
+  "timeToFix" : 5,
+  "title" : "There should not be empty lines between an annotation and the object that it's annotating"
+}, {
+  "patternId" : "ArgumentListWrapping",
+  "description" : "Reports incorrect argument list wrapping",
+  "timeToFix" : 5,
+  "title" : "Reports incorrect argument list wrapping"
 }, {
   "patternId" : "ChainWrapping",
   "description" : "Checks if condition chaining is wrapped right",
@@ -449,6 +464,11 @@
   "timeToFix" : 5,
   "title" : "Property names inside objects should follow the naming convention set in the projects configuration."
 }, {
+  "patternId" : "NonBooleanPropertyPrefixedWithIs",
+  "description" : "Only boolean property names can start with 'is' prefix.",
+  "timeToFix" : 5,
+  "title" : "Only boolean property names can start with 'is' prefix."
+}, {
   "patternId" : "PackageNaming",
   "description" : "Package names should match the naming convention set in the configuration.",
   "timeToFix" : 5,
@@ -505,9 +525,9 @@
   "title" : "Using the forEach method on ranges has a heavy performance cost. Prefer using simple for loops."
 }, {
   "patternId" : "SpreadOperator",
-  "description" : "In most cases using a spread operator causes a full copy of the array to be created before calling a method which has a very high performance penalty.",
+  "description" : "In most cases using a spread operator causes a full copy of the array to be created before calling a method. This may result in a performance penalty.",
   "timeToFix" : 5,
-  "title" : "In most cases using a spread operator causes a full copy of the array to be created before calling a method which has a very high performance penalty."
+  "title" : "In most cases using a spread operator causes a full copy of the array to be created before calling a method. This may result in a performance penalty."
 }, {
   "patternId" : "UnnecessaryTemporaryInstantiation",
   "description" : "Avoid temporary objects when converting primitive types to String.",
@@ -638,6 +658,16 @@
   "description" : "Functions using expression statements have an implicit return type.\nChanging the type of the expression accidentally, changes the function return type.\nThis may lead to backward incompatibility.\nUse a block statement to make clear this function will never return a value.",
   "timeToFix" : 5,
   "title" : "Functions using expression statements have an implicit return type.\nChanging the type of the expression accidentally, changes the function return type.\nThis may lead to backward incompatibility."
+}, {
+  "patternId" : "NullableToStringCall",
+  "description" : "This call may return the string \"null\"",
+  "timeToFix" : 5,
+  "title" : "This call may return the string \"null\""
+}, {
+  "patternId" : "ClassOrdering",
+  "description" : "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; method declarations then companion objects.",
+  "timeToFix" : 5,
+  "title" : "Class contents should be in this order: Property declarations/initializer blocks; secondary constructors; method declarations then companion objects."
 }, {
   "patternId" : "CollapsibleIfStatements",
   "description" : "Two if statements which could be collapsed were detected. These statements can be merged to improve readability.",
@@ -830,9 +860,9 @@
   "title" : "The explicit public modifier still results in an internal nested class."
 }, {
   "patternId" : "RedundantVisibilityModifierRule",
-  "description" : "Checks for redundant visibility modifiers. Public is the default visibility for classes. The public modifier is redundant.",
+  "description" : "Checks for redundant visibility modifiers.",
   "timeToFix" : 5,
-  "title" : "Checks for redundant visibility modifiers. Public is the default visibility for classes. The public modifier is redundant."
+  "title" : "Checks for redundant visibility modifiers."
 }, {
   "patternId" : "UntilInsteadOfRangeTo",
   "description" : "'..' call can be replaced with 'until'",
@@ -919,6 +949,11 @@
   "timeToFix" : 5,
   "title" : "Type does not need to be stated explicitly and can be removed."
 }, {
+  "patternId" : "LibraryEntitiesShouldNotBePublic",
+  "description" : "Library class should not be public",
+  "timeToFix" : 5,
+  "title" : "Library class should not be public"
+}, {
   "patternId" : "LibraryCodeMustSpecifyReturnType",
   "description" : "Library functions/properties should have an explicit return type. Inferred return type can easily be changed by mistake which may lead to breaking changes.",
   "timeToFix" : 5,
@@ -928,4 +963,34 @@
   "description" : "Array literals '[...]' should be preferred as they are more readable than 'arrayOf(...)' expressions.",
   "timeToFix" : 5,
   "title" : "Array literals '[...]' should be preferred as they are more readable than 'arrayOf(...)' expressions."
+}, {
+  "patternId" : "UseEmptyCounterpart",
+  "description" : "Instantiation of an object's \"empty\" state should use the object's \"empty\" initializer",
+  "timeToFix" : 5,
+  "title" : "Instantiation of an object's \"empty\" state should use the object's \"empty\" initializer"
+}, {
+  "patternId" : "UseCheckNotNull",
+  "description" : "Use checkNotNull() instead of check() for checking not-null.",
+  "timeToFix" : 5,
+  "title" : "Use checkNotNull() instead of check() for checking not-null."
+}, {
+  "patternId" : "UseRequireNotNull",
+  "description" : "Use requireNotNull() instead of require() for checking not-null.",
+  "timeToFix" : 5,
+  "title" : "Use requireNotNull() instead of require() for checking not-null."
+}, {
+  "patternId" : "GlobalCoroutineUsage",
+  "description" : "Usage of GlobalScope instance is highly discouraged",
+  "timeToFix" : 5,
+  "title" : "Usage of GlobalScope instance is highly discouraged"
+}, {
+  "patternId" : "RedundantSuspendModifier",
+  "description" : "`suspend` modifier is only needed for functions that contain suspending calls",
+  "timeToFix" : 5,
+  "title" : "`suspend` modifier is only needed for functions that contain suspending calls"
+}, {
+  "patternId" : "SuspendFunWithFlowReturnType",
+  "description" : "`suspend` modifier should not be used for functions that return a Coroutines Flow type. Flows are cold streams and invoking a function that returns one should not produce any side effects.",
+  "timeToFix" : 5,
+  "title" : "`suspend` modifier should not be used for functions that return a Coroutines Flow type. Flows are cold streams and invoking a function that returns one should not produce any side effects."
 } ]

--- a/docs/multiple-tests/max-line-length/src/maxLineLength.kt
+++ b/docs/multiple-tests/max-line-length/src/maxLineLength.kt
@@ -2,8 +2,7 @@ package hello
 /**
  *This is a test!
  */
-fun main(args : Array<String>) {
+fun main(args: Array<String>) {
     println(getHelloString()
-);
+)
 }
-

--- a/docs/multiple-tests/no-crash-with-zero-results/src/detekt.yml
+++ b/docs/multiple-tests/no-crash-with-zero-results/src/detekt.yml
@@ -1,6 +1,3 @@
-autoCorrect: false
-failFast: false
-
 comments:
   active: true
   CommentOverPrivateFunction:
@@ -95,7 +92,7 @@ exceptions:
   active: true
   TooGenericExceptionCaught:
     active: true
-    exceptions:
+    exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
      - Exception
@@ -109,7 +106,7 @@ exceptions:
     methodNames: 'toString,hashCode,equals,finalize'
   TooGenericExceptionThrown:
     active: true
-    exceptions:
+    exceptionNames:
      - Error
      - Exception
      - NullPointerException
@@ -178,6 +175,51 @@ potential-bugs:
     active: false
   UnsafeCast:
     active: false
+naming:
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  FunctionNaming:
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  MatchingDeclarationName:
+    active: true
 
 style:
   active: true
@@ -217,48 +259,6 @@ style:
   LoopWithTooManyJumpStatements:
     active: false
     maxJumpCount: 1
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
-  VariableNaming:
-    active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
-    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  TopLevelPropertyNaming:
-    active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
-  ObjectPropertyNaming:
-    active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-  PackageNaming:
-    active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
-  ClassNaming:
-    active: true
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
-  EnumNaming:
-    active: true
-    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming:
-    active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
-  FunctionMaxLength:
-    active: false
-    maximumFunctionNameLength: 30
-  FunctionMinLength:
-    active: false
-    minimumFunctionNameLength: 3
-  ForbiddenClassName:
-    active: false
-    forbiddenName: ''
   SafeCast:
     active: true
   UnnecessaryAbstractClass:
@@ -269,11 +269,7 @@ style:
     active: false
   UtilityClassWithPublicConstructor:
     active: false
-  OptionalAbstractKeyworMagicNumberd:
-    active: true
   OptionalWhenBraces:
-    active: false
-  OptionalReturnKeyword:
     active: false
   OptionalUnit:
     active: false
@@ -282,7 +278,7 @@ style:
   SerialVersionUIDInSerializableClass:
     active: false
   MagicNumber:
-    active: true
+    active: false
     ignoreNumbers: '-1,0,1,2'
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
@@ -306,7 +302,9 @@ style:
     active: false
   RedundantVisibilityModifierRule:
     active: false
-  MatchingDeclarationName:
-    active: true
   UntilInsteadOfRangeTo:
+    active: false
+
+formatting:
+  SpacingAroundColon:
     active: false

--- a/docs/multiple-tests/no-crash-with-zero-results/src/noResults.kt
+++ b/docs/multiple-tests/no-crash-with-zero-results/src/noResults.kt
@@ -2,7 +2,6 @@ package hello
 /**
  *This is a test!
  */
-fun main(args : Array<String>) {
+fun main(args: Array<String>) {
     println(getHelloString())
 }
-

--- a/docs/multiple-tests/prefer-config-over-native/src/detekt.yml
+++ b/docs/multiple-tests/prefer-config-over-native/src/detekt.yml
@@ -1,6 +1,3 @@
-autoCorrect: false
-failFast: false
-
 comments:
   active: true
   CommentOverPrivateFunction:
@@ -95,7 +92,7 @@ exceptions:
   active: true
   TooGenericExceptionCaught:
     active: true
-    exceptions:
+    exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
      - Exception
@@ -109,7 +106,7 @@ exceptions:
     methodNames: 'toString,hashCode,equals,finalize'
   TooGenericExceptionThrown:
     active: true
-    exceptions:
+    exceptionNames:
      - Error
      - Exception
      - NullPointerException
@@ -178,6 +175,51 @@ potential-bugs:
     active: false
   UnsafeCast:
     active: false
+naming:
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  FunctionNaming:
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  MatchingDeclarationName:
+    active: true
 
 style:
   active: true
@@ -217,48 +259,6 @@ style:
   LoopWithTooManyJumpStatements:
     active: false
     maxJumpCount: 1
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
-  VariableNaming:
-    active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
-    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  TopLevelPropertyNaming:
-    active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
-  ObjectPropertyNaming:
-    active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-  PackageNaming:
-    active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
-  ClassNaming:
-    active: true
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
-  EnumNaming:
-    active: true
-    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming:
-    active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
-  FunctionMaxLength:
-    active: false
-    maximumFunctionNameLength: 30
-  FunctionMinLength:
-    active: false
-    minimumFunctionNameLength: 3
-  ForbiddenClassName:
-    active: false
-    forbiddenName: ''
   SafeCast:
     active: true
   UnnecessaryAbstractClass:
@@ -269,11 +269,7 @@ style:
     active: false
   UtilityClassWithPublicConstructor:
     active: false
-  OptionalAbstractKeyworMagicNumberd:
-    active: true
   OptionalWhenBraces:
-    active: false
-  OptionalReturnKeyword:
     active: false
   OptionalUnit:
     active: false
@@ -306,9 +302,9 @@ style:
     active: false
   RedundantVisibilityModifierRule:
     active: false
-  MatchingDeclarationName:
-    active: true
   UntilInsteadOfRangeTo:
     active: false
+
+formatting:
   SpacingAroundColon:
     active: false

--- a/docs/multiple-tests/prefer-config-over-native/src/detekt.yml
+++ b/docs/multiple-tests/prefer-config-over-native/src/detekt.yml
@@ -310,3 +310,5 @@ style:
     active: true
   UntilInsteadOfRangeTo:
     active: false
+  SpacingAroundColon:
+    active: false

--- a/docs/multiple-tests/with-config-file/src/detekt.yml
+++ b/docs/multiple-tests/with-config-file/src/detekt.yml
@@ -1,6 +1,3 @@
-autoCorrect: false
-failFast: false
-
 comments:
   active: true
   CommentOverPrivateFunction:
@@ -95,7 +92,7 @@ exceptions:
   active: true
   TooGenericExceptionCaught:
     active: true
-    exceptions:
+    exceptionNames:
      - ArrayIndexOutOfBoundsException
      - Error
      - Exception
@@ -109,7 +106,7 @@ exceptions:
     methodNames: 'toString,hashCode,equals,finalize'
   TooGenericExceptionThrown:
     active: true
-    exceptions:
+    exceptionNames:
      - Error
      - Exception
      - NullPointerException
@@ -178,6 +175,51 @@ potential-bugs:
     active: false
   UnsafeCast:
     active: false
+naming:
+  PackageNaming:
+    active: true
+    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
+  FunctionNaming:
+    active: true
+    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+  VariableMinLength:
+    active: false
+    minimumVariableNameLength: 1
+  VariableMaxLength:
+    active: false
+    maximumVariableNameLength: 64
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z\d]*'
+    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+  ObjectPropertyNaming:
+    active: true
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  MemberNameEqualsClassName:
+    active: false
+    ignoreOverriddenFunction: true
+  ForbiddenClassName:
+    active: false
+    forbiddenName: ''
+  FunctionMaxLength:
+    active: false
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    minimumFunctionNameLength: 3
+  MatchingDeclarationName:
+    active: true
 
 style:
   active: true
@@ -217,48 +259,6 @@ style:
   LoopWithTooManyJumpStatements:
     active: false
     maxJumpCount: 1
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverriddenFunction: true
-  VariableNaming:
-    active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
-    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  TopLevelPropertyNaming:
-    active: true
-    constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
-  ObjectPropertyNaming:
-    active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
-  PackageNaming:
-    active: true
-    packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
-  ClassNaming:
-    active: true
-    classPattern: '[A-Z$][a-zA-Z0-9$]*'
-  EnumNaming:
-    active: true
-    enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
-  FunctionNaming:
-    active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
-  FunctionMaxLength:
-    active: false
-    maximumFunctionNameLength: 30
-  FunctionMinLength:
-    active: false
-    minimumFunctionNameLength: 3
-  ForbiddenClassName:
-    active: false
-    forbiddenName: ''
   SafeCast:
     active: true
   UnnecessaryAbstractClass:
@@ -269,11 +269,7 @@ style:
     active: false
   UtilityClassWithPublicConstructor:
     active: false
-  OptionalAbstractKeyworMagicNumberd:
-    active: true
   OptionalWhenBraces:
-    active: false
-  OptionalReturnKeyword:
     active: false
   OptionalUnit:
     active: false
@@ -306,8 +302,6 @@ style:
     active: false
   RedundantVisibilityModifierRule:
     active: false
-  MatchingDeclarationName:
-    active: true
   UntilInsteadOfRangeTo:
     active: false
 

--- a/docs/multiple-tests/with-config-file/src/detekt.yml
+++ b/docs/multiple-tests/with-config-file/src/detekt.yml
@@ -310,3 +310,7 @@ style:
     active: true
   UntilInsteadOfRangeTo:
     active: false
+
+formatting:
+  SpacingAroundColon:
+    active: false

--- a/docs/multiple-tests/with-config-file/src/results.kt
+++ b/docs/multiple-tests/with-config-file/src/results.kt
@@ -8,4 +8,3 @@ fun main(args : Array<String>) {
     val myDouble = 2.0F
     println(getHelloString())
 }
-

--- a/docs/multiple-tests/without-config-file/src/results.kt
+++ b/docs/multiple-tests/without-config-file/src/results.kt
@@ -2,10 +2,9 @@ package hello
 /**
  *This is a test
  */
-fun main(args : Array<String>) {
+fun main(args: Array<String>) {
     val myFloat = 4.0F
     val myFloat = 1.0F
     val myDouble = 2.0F
     println(getHelloString())
 }
-

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name" : "detekt",
-  "version" : "1.10.0",
+  "version" : "1.14.2",
   "patterns" : [ {
     "patternId" : "CommentOverPrivateFunction",
     "level" : "Warning",
@@ -91,6 +91,11 @@
     "level" : "Warning",
     "category" : "ErrorProne",
     "enabled" : true
+  }, {
+    "patternId" : "ReplaceSafeCallChainWithRun",
+    "level" : "Warning",
+    "category" : "ErrorProne",
+    "enabled" : false
   }, {
     "patternId" : "EmptyCatchBlock",
     "level" : "Warning",
@@ -233,6 +238,16 @@
     "enabled" : false
   }, {
     "patternId" : "AnnotationOnSeparateLine",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "AnnotationSpacing",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "ArgumentListWrapping",
     "level" : "Info",
     "category" : "CodeStyle",
     "enabled" : false
@@ -452,6 +467,11 @@
     "category" : "CodeStyle",
     "enabled" : false
   }, {
+    "patternId" : "NonBooleanPropertyPrefixedWithIs",
+    "level" : "Warning",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
     "patternId" : "PackageNaming",
     "level" : "Info",
     "category" : "CodeStyle",
@@ -640,6 +660,16 @@
     "patternId" : "ImplicitUnitReturnType",
     "level" : "Warning",
     "category" : "ErrorProne",
+    "enabled" : false
+  }, {
+    "patternId" : "NullableToStringCall",
+    "level" : "Warning",
+    "category" : "ErrorProne",
+    "enabled" : false
+  }, {
+    "patternId" : "ClassOrdering",
+    "level" : "Info",
+    "category" : "CodeStyle",
     "enabled" : false
   }, {
     "patternId" : "CollapsibleIfStatements",
@@ -922,6 +952,11 @@
     "category" : "CodeStyle",
     "enabled" : false
   }, {
+    "patternId" : "LibraryEntitiesShouldNotBePublic",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
     "patternId" : "LibraryCodeMustSpecifyReturnType",
     "level" : "Info",
     "category" : "CodeStyle",
@@ -930,6 +965,36 @@
     "patternId" : "UseArrayLiteralsInAnnotations",
     "level" : "Info",
     "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "UseEmptyCounterpart",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "UseCheckNotNull",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "UseRequireNotNull",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
+    "patternId" : "GlobalCoroutineUsage",
+    "level" : "Warning",
+    "category" : "ErrorProne",
+    "enabled" : false
+  }, {
+    "patternId" : "RedundantSuspendModifier",
+    "level" : "Warning",
+    "category" : "ErrorProne",
+    "enabled" : false
+  }, {
+    "patternId" : "SuspendFunWithFlowReturnType",
+    "level" : "Warning",
+    "category" : "ErrorProne",
     "enabled" : false
   } ]
 }

--- a/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
+++ b/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
@@ -1,5 +1,6 @@
 package codacy.detekt
 
+import io.github.detekt.tooling.dsl.ProcessingSpecBuilder
 import java.nio.file.Path
 
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
@@ -9,11 +10,15 @@ class ProcessingSettingsFactory {
   companion object {
     @JvmStatic
     fun create(paths: List<Path>, config: Config): ProcessingSettings {
-      return ProcessingSettings (inputPaths = paths, config = config, outPrinter = System.out, errPrinter = System.err)
+      val processingSpec = ProcessingSpecBuilder()
+      processingSpec.project { this.inputPaths = paths }
+      return ProcessingSettings (processingSpec.build(), config)
     }
     @JvmStatic
     fun create(paths: List<Path>): ProcessingSettings {
-      return ProcessingSettings (inputPaths = paths, outPrinter = System.out, errPrinter = System.err)
+      val processingSpec = ProcessingSpecBuilder()
+      processingSpec.project { this.inputPaths = paths }
+      return ProcessingSettings (processingSpec.build(), Config.empty)
     }
   }
 }

--- a/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
+++ b/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
@@ -16,6 +16,11 @@ class ProcessingSettingsFactory {
           inputPaths = paths
         }
         config { useDefaultConfig = true }
+        rules {
+          autoCorrect = false
+          // this is the same as failFast according to the documentation inside the code
+          activateExperimentalRules = false
+        }
       }
       return ProcessingSettings(processingSpec, config)
     }

--- a/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
+++ b/src/main/kotlin/codacy/detekt/ProcessingSettingsFactory.kt
@@ -1,5 +1,6 @@
 package codacy.detekt
 
+import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.dsl.ProcessingSpecBuilder
 import java.nio.file.Path
 
@@ -10,15 +11,17 @@ class ProcessingSettingsFactory {
   companion object {
     @JvmStatic
     fun create(paths: List<Path>, config: Config): ProcessingSettings {
-      val processingSpec = ProcessingSpecBuilder()
-      processingSpec.project { this.inputPaths = paths }
-      return ProcessingSettings (processingSpec.build(), config)
+      val processingSpec = ProcessingSpec {
+        project {
+          inputPaths = paths
+        }
+        config { useDefaultConfig = true }
+      }
+      return ProcessingSettings(processingSpec, config)
     }
     @JvmStatic
     fun create(paths: List<Path>): ProcessingSettings {
-      val processingSpec = ProcessingSpecBuilder()
-      processingSpec.project { this.inputPaths = paths }
-      return ProcessingSettings (processingSpec.build(), Config.empty)
+      return create(paths, Config.empty)
     }
   }
 }

--- a/src/main/scala/codacy/detekt/Detekt.scala
+++ b/src/main/scala/codacy/detekt/Detekt.scala
@@ -102,9 +102,7 @@ object Detekt extends Tool {
           (category.value.toLowerCase, (Map(("active", patternsRaw.nonEmpty)) ++ patterns).asJava)
       }
 
-    val ourConf = Map(("autoCorrect", false), ("failFast", false)) ++ configMapGen
-
-    YamlConfigFactory.create(ourConf.asJava)
+    YamlConfigFactory.create(configMapGen.asJava)
   }
 
   private def getResults(path: Path, filesOpt: Option[Set[api.Source.File]], yamlConf: YamlConfig): List[Finding] = {
@@ -112,7 +110,7 @@ object Detekt extends Tool {
     val providers = new RuleSetLocator(settings).load()
     val processors = List.empty[FileProcessListener]
     val analyzer = new Analyzer(settings, providers, processors.asJava)
-    val compiler = new KtTreeCompiler(settings, settings.getSpec.getProjectSpec, new KtCompiler())
+    val compiler = new KtTreeCompiler(settings, settings.getSpec.getProjectSpec, new KtCompiler)
 
     val detektion = filesOpt match {
       case None =>

--- a/src/main/scala/codacy/detekt/Detekt.scala
+++ b/src/main/scala/codacy/detekt/Detekt.scala
@@ -9,8 +9,9 @@ import com.codacy.plugins.api.results.{Pattern, Result, Tool}
 import com.codacy.tools.scala.seed.utils.FileHelper
 import io.gitlab.arturbosch.detekt.api._
 import io.gitlab.arturbosch.detekt.api.internal.YamlConfig
-import io.gitlab.arturbosch.detekt.core._
+import io.gitlab.arturbosch.detekt.core.rules._
 import io.github.detekt.parser.KtCompiler
+import io.gitlab.arturbosch.detekt.core.{Analyzer, KtTreeCompiler}
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.yaml.snakeyaml.Yaml
 import play.api.libs.json.{JsString, Json}
@@ -110,16 +111,16 @@ object Detekt extends Tool {
     val settings = ProcessingSettingsFactory.create(Seq(path).asJava, yamlConf)
     val providers = new RuleSetLocator(settings).load()
     val processors = List.empty[FileProcessListener]
-    val detektor = new Detektor(settings, providers, processors.asJava)
-    val compiler = new KtTreeCompiler(settings, new KtCompiler())
+    val analyzer = new Analyzer(settings, providers, processors.asJava)
+    val compiler = new KtTreeCompiler(settings, settings.getSpec.getProjectSpec, new KtCompiler())
 
     val detektion = filesOpt match {
       case None =>
         val ktFiles = compiler.compile(path)
-        detektor.run(ktFiles, BindingContext.EMPTY)
+        analyzer.run(ktFiles, BindingContext.EMPTY)
       case Some(files) =>
         val ktFiles = files.par.flatMap(file => compiler.compile(Paths.get(file.path)).asScala).seq.asJava
-        detektor.run(ktFiles, BindingContext.EMPTY)
+        analyzer.run(ktFiles, BindingContext.EMPTY)
     }
 
     detektion.values.asScala.flatMap(_.asScala).toList

--- a/src/main/scala/codacy/detekt/DocGenerator.scala
+++ b/src/main/scala/codacy/detekt/DocGenerator.scala
@@ -2,6 +2,7 @@ package codacy.detekt
 
 import better.files.File
 import io.github.detekt.parser.KtCompiler
+import io.github.detekt.tooling.dsl.ProjectSpecBuilder
 import io.gitlab.arturbosch.detekt.api._
 import io.gitlab.arturbosch.detekt.core.KtTreeCompiler
 import io.gitlab.arturbosch.detekt.generator.collection.DetektCollector
@@ -197,7 +198,8 @@ object DocGenerator {
       .map(_.path)
 
     val collector = new DetektCollector()
-    val compiler = new KtTreeCompiler(ProcessingSettingsFactory.create(Seq.empty.asJava), new KtCompiler())
+    val processingSettings = ProcessingSettingsFactory.create(Seq.empty.asJava)
+    val compiler = new KtTreeCompiler(processingSettings, new ProjectSpecBuilder().build(), new KtCompiler())
 
     val ktFiles: Array[KtFile] = filePaths
       .to(Array)

--- a/src/main/scala/codacy/detekt/Providers.scala
+++ b/src/main/scala/codacy/detekt/Providers.scala
@@ -1,7 +1,14 @@
 package codacy.detekt
 
 import io.gitlab.arturbosch.detekt.formatting.FormattingProvider
-import io.gitlab.arturbosch.detekt.rules.providers._
+import io.gitlab.arturbosch.detekt.rules.bugs.PotentialBugProvider
+import io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider
+import io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider
+import io.gitlab.arturbosch.detekt.rules.empty.EmptyCodeProvider
+import io.gitlab.arturbosch.detekt.rules.exceptions.ExceptionsProvider
+import io.gitlab.arturbosch.detekt.rules.naming.NamingProvider
+import io.gitlab.arturbosch.detekt.rules.performance.PerformanceProvider
+import io.gitlab.arturbosch.detekt.rules.style.StyleGuideProvider
 
 object Providers {
 

--- a/src/main/scala/codacy/detekt/Providers.scala
+++ b/src/main/scala/codacy/detekt/Providers.scala
@@ -3,6 +3,7 @@ package codacy.detekt
 import io.gitlab.arturbosch.detekt.formatting.FormattingProvider
 import io.gitlab.arturbosch.detekt.rules.bugs.PotentialBugProvider
 import io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider
+import io.gitlab.arturbosch.detekt.rules.coroutines.CoroutinesProvider
 import io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider
 import io.gitlab.arturbosch.detekt.rules.empty.EmptyCodeProvider
 import io.gitlab.arturbosch.detekt.rules.exceptions.ExceptionsProvider
@@ -21,6 +22,7 @@ object Providers {
     new NamingProvider,
     new PerformanceProvider,
     new PotentialBugProvider,
-    new StyleGuideProvider
+    new StyleGuideProvider,
+    new CoroutinesProvider
   )
 }


### PR DESCRIPTION
These patterns were moved from `style` to `naming`:
- PackageNaming
- ClassNaming
- EnumNaming
- FunctionNaming
- VariableNaming
- VariableMinLength
- VariableMaxLength
- TopLevelPropertyNaming
- ObjectPropertyNaming
- MemberNameEqualsClassName
- ForbiddenClassName
- FunctionMaxLength
- FunctionMinLength
- MatchingDeclarationName