### PR TITLE
Bump detekt to 1.18.1 CY-4888

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 name := "codacy-detekt"
 
 scalaVersion := "2.13.1"
+kotlinVersion := "1.5.21"
 
-lazy val detektVersion = Def.setting("1.17.1")
+lazy val detektVersion = Def.setting("1.18.1")
 
 Compile / sourceGenerators += Def.task {
   val file = (Compile / sourceManaged).value / "codacy" / "detekt" / "Versions.scala"

--- a/docs/description/AvoidReferentialEquality.md
+++ b/docs/description/AvoidReferentialEquality.md
@@ -1,0 +1,20 @@
+# AvoidReferentialEquality
+
+Kotlin supports two types of equality: structural equality and referential equality. While there are
+use cases for both, checking for referential equality for some types (such as `String` or `List`) is
+likely not intentional and may case unexpected results.
+
+## Noncompliant Code
+
+```kotlin
+    val areEqual = "aString" === otherString
+    val areNotEqual = "aString" !== otherString
+```
+## Compliant Code
+
+```kotlin
+    val areEqual = "aString" == otherString
+    val areNotEqual = "aString" != otherString
+```
+
+[Source](https://arturbosch.github.io/detekt/potential-bugs.html#avoidreferentialequality)

--- a/docs/description/BooleanPropertyNaming.md
+++ b/docs/description/BooleanPropertyNaming.md
@@ -1,0 +1,16 @@
+# BooleanPropertyNaming
+
+Reports when a boolean property doesn't match a pattern
+
+## Noncompliant Code
+
+```kotlin
+val progressBar: Boolean = true
+```
+## Compliant Code
+
+```kotlin
+val hasProgressBar: Boolean = true
+```
+
+[Source](https://arturbosch.github.io/detekt/naming.html#booleanpropertynaming)

--- a/docs/description/DoubleMutabilityForCollection.md
+++ b/docs/description/DoubleMutabilityForCollection.md
@@ -1,0 +1,27 @@
+# DoubleMutabilityForCollection
+
+Using `var` when declaring a mutable collection leads to double mutability. Consider instead
+declaring your variable with `val` or switching your declaration to use an immutable type.
+
+## Noncompliant Code
+
+```kotlin
+var myList = mutableListOf(1,2,3)
+var mySet = mutableSetOf(1,2,3)
+var myMap = mutableMapOf("answer" to 42)
+```
+## Compliant Code
+
+```kotlin
+// Use val
+val myList = mutableListOf(1,2,3)
+val mySet = mutableSetOf(1,2,3)
+val myMap = mutableMapOf("answer" to 42)
+
+// Use immutable types
+var myList = listOf(1,2,3)
+var mySet = setOf(1,2,3)
+var myMap = mapOf("answer" to 42)
+```
+
+[Source](https://arturbosch.github.io/detekt/potential-bugs.html#doublemutabilityforcollection)

--- a/docs/description/ImplicitUnitReturnType.md
+++ b/docs/description/ImplicitUnitReturnType.md
@@ -5,5 +5,22 @@ Changing the type of the expression accidentally, changes the functions return t
 This may lead to backward incompatibility.
 Use a block statement to make clear this function will never return a value.
 
+## Noncompliant Code
+
+```kotlin
+fun errorProneUnit() = println("Hello Unit")
+fun errorProneUnitWithParam(param: String) = param.run { println(this) }
+fun String.errorProneUnitWithReceiver() = run { println(this) }
+```
+## Compliant Code
+
+```kotlin
+fun blockStatementUnit() {
+    // code
+}
+
+// explicit Unit is compliant by default; can be configured to enforce block statement
+fun safeUnitReturn(): Unit = println("Hello Unit")
+```
 
 [Source](https://arturbosch.github.io/detekt/potential-bugs.html#implicitunitreturntype)

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -100,9 +100,9 @@
   "title" : "Chains of safe calls on non-nullable types can be surrounded with run {}"
 }, {
   "patternId" : "NamedArguments",
-  "description" : "Function invocation with more than 3 parameters must all be named",
+  "description" : "Parameters of function invocation must all be named",
   "timeToFix" : 5,
-  "title" : "Function invocation with more than 3 parameters must all be named"
+  "title" : "Parameters of function invocation must all be named"
 }, {
   "patternId" : "EmptyCatchBlock",
   "description" : "Empty catch block detected. Empty catch blocks indicate that an exception is ignored and not handled.",
@@ -539,6 +539,11 @@
   "timeToFix" : 5,
   "title" : "Function parameter names should follow the naming convention set in the projects configuration."
 }, {
+  "patternId" : "BooleanPropertyNaming",
+  "description" : "Boolean property name should follow the naming convention set in the projects configuration",
+  "timeToFix" : 5,
+  "title" : "Boolean property name should follow the naming convention set in the projects configuration"
+}, {
   "patternId" : "InvalidPackageDeclaration",
   "description" : "Kotlin source files should be stored in the directory corresponding to its package statement.",
   "timeToFix" : 5,
@@ -569,6 +574,11 @@
   "timeToFix" : 5,
   "title" : "Using Array<Primitive> leads to implicit boxing and a performance hit"
 }, {
+  "patternId" : "AvoidReferentialEquality",
+  "description" : "Avoid using referential equality checks",
+  "timeToFix" : 5,
+  "title" : "Avoid using referential equality checks"
+}, {
   "patternId" : "Deprecation",
   "description" : "Deprecated elements should not be used.",
   "timeToFix" : 5,
@@ -579,7 +589,7 @@
   "timeToFix" : 5,
   "title" : "Down-casting immutable collection types is breaking the collection contract"
 }, {
-  "patternId" : "DoubleMutabilityInCollection",
+  "patternId" : "DoubleMutabilityForCollection",
   "description" : "Using var with mutable collections leads to double mutability. Consider using val or immutable collection types.",
   "timeToFix" : 5,
   "title" : "Using var with mutable collections leads to double mutability. Consider using val or immutable collection types."

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name" : "detekt",
-  "version" : "1.17.1",
+  "version" : "1.18.1",
   "patterns" : [ {
     "patternId" : "CommentOverPrivateFunction",
     "level" : "Warning",
@@ -542,6 +542,11 @@
     "category" : "CodeStyle",
     "enabled" : false
   }, {
+    "patternId" : "BooleanPropertyNaming",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
     "patternId" : "InvalidPackageDeclaration",
     "level" : "Warning",
     "category" : "ErrorProne",
@@ -572,6 +577,11 @@
     "category" : "Performance",
     "enabled" : false
   }, {
+    "patternId" : "AvoidReferentialEquality",
+    "level" : "Warning",
+    "category" : "CodeStyle",
+    "enabled" : false
+  }, {
     "patternId" : "Deprecation",
     "level" : "Warning",
     "category" : "ErrorProne",
@@ -582,7 +592,7 @@
     "category" : "CodeStyle",
     "enabled" : false
   }, {
-    "patternId" : "DoubleMutabilityInCollection",
+    "patternId" : "DoubleMutabilityForCollection",
     "level" : "Info",
     "category" : "CodeStyle",
     "enabled" : false


### PR DESCRIPTION
Also bumps Kotlin version to 1.5.21 (as it was failing on some binary compatibility problems without it)
https://github.com/detekt/detekt/pull/3956