### PR TITLE
fix: bump orb to fix curl binary issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@10.2.2
+  codacy: codacy/base@10.2.3
   codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:


### PR DESCRIPTION
Bumps orb version to fix an issue with the alpine curl binary used during the checkout step in ci.